### PR TITLE
Add in-publish package in order to only execute prepublish script when NPM publish is run

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "minitypeahead",
-	"version": "2.0.6",
+	"version": "2.1.0",
 	"description": "A small and lightweight typeahead that is easily extendable",
 	"homepage": "https://github.com/wampiedriessen/minitypeahead/",
 	"main": "lib/bundle.js",
@@ -11,15 +11,16 @@
 	},
 	"dependencies": {
 		"jquery": "*",
-		"latinize": "git://github.com/wampiedriessen/latinize.git"
+		"latinize": "git://github.com/wampiedriessen/latinize.git",
+		"in-publish": "~2.0.0"
 	},
-	"bundledDependencies": {
-		"latinize": "git://github.com/wampiedriessen/latinize.git"
-	},
+	"bundledDependencies": [
+		"latinize"
+	],
 	"devDependencies": {
 		"coffee-script": ">=1.10.0"
 	},
 	"scripts": {
-		"prepublish": "cake build; cat node_modules/latinize/dist/latinize.js lib/minitypeahead.js > lib/bundle.js"
+		"prepublish": "in-publish && cake build && (cat node_modules/latinize/dist/latinize.js lib/minitypeahead.js > lib/bundle.js) || not-in-publish"
 	}
 }


### PR DESCRIPTION
Probleem dat we hadden is dat het prepublish script ook wordt gedraaid op npm install, maar bij npm install heb je waarschijnlijk de dependency /node_modules/latinize niet, dus gaat de prepublish script ook mis. Je zou echter prepublish alleen moeten draaien op npm publish.

Ik heb de `in-publish` package toegevoegd die je dit laat checken, dus als het goed is zou hiermee alles moeten werken.